### PR TITLE
Feat: 씬 기반 상속 싱글톤 구현

### DIFF
--- a/Assets/Scripts/Util/SceneSingleton.cs
+++ b/Assets/Scripts/Util/SceneSingleton.cs
@@ -1,0 +1,44 @@
+﻿using UnityEngine;
+
+namespace Util
+{
+    /// <summary>
+    /// 씬이 변경될 시 데이터를 초기화하는 싱글톤<br/>
+    /// 한 씬 내부에서만 사용하는 게 일반적이나 자유롭게 활용 가능 <br/>
+    /// 일반 싱글톤과 마찬가지로 상속해서 사용 가능
+    /// </summary>
+    /// <typeparam name="T">싱글톤으로 구현할 클래스</typeparam>
+    public class SceneSingleton<T> : MonoBehaviour where T : MonoBehaviour
+    {
+        private static T _instance;
+        public static T Instance { get { Init(); return _instance; } }
+
+        public void Awake()
+        {
+            if (_instance == null)
+                _instance = this as T;
+            else if (_instance != this)
+                Destroy(gameObject);
+        }
+
+        static bool Init()
+        {
+            if (_instance == null)
+            {
+                _instance = FindObjectOfType<T>();
+            
+                if (_instance == null)
+                {
+                    GameObject obj = new GameObject { name = typeof(T).ToString() + "(Singleton)" };
+                    _instance = obj.AddComponent<T>();
+                    return true;
+                }
+
+                return false;
+            }
+
+            return true;
+        }
+    }
+
+}

--- a/Assets/Scripts/Util/SceneSingleton.cs.meta
+++ b/Assets/Scripts/Util/SceneSingleton.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e44f708363b54df7acb1ffb6290d631a
+timeCreated: 1751437784

--- a/Assets/Scripts/Util/Singleton.cs
+++ b/Assets/Scripts/Util/Singleton.cs
@@ -1,0 +1,38 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Singleton<T> : MonoBehaviour where T : MonoBehaviour
+{
+    private static T _instance;
+    public static T Instance { get { Init(); return _instance; } }
+
+    public void Awake()
+    {
+        if(Init())
+            Destroy(gameObject);
+    }
+
+    static bool Init()
+    {
+        if (_instance == null)
+        {
+            _instance = FindObjectOfType<T>();
+            GameObject obj;
+            
+            if (_instance == null)
+            {
+                obj = new GameObject { name = typeof(T).ToString() + "(Singleton)" };
+                _instance = obj.AddComponent<T>();
+                DontDestroyOnLoad(obj);
+                return true;
+            }
+
+            obj = _instance.gameObject;
+            DontDestroyOnLoad(obj);
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/Assets/Scripts/Util/Singleton.cs.meta
+++ b/Assets/Scripts/Util/Singleton.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 883eca8c98faf2c4fa092f10cc459d78
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 사용방법

상속으로 간편하게 사용할 수 있습니다.
해당 싱글톤은 씬 내에서만 사용이 가능합니다.
씬에 배치할 필요 없이 호출하면 자동으로 생성됩니다.
만약 씬과 무관하게 싱글톤이 필요할 경우 #3 을 참고해주세요.