### PR TITLE
Feat: GameplayAbilitySpec 구현(Ability의 상태/데이터 분리) / 스킬 구현

### DIFF
--- a/Assets/Scenes/Test/PlayerInput.unity
+++ b/Assets/Scenes/Test/PlayerInput.unity
@@ -135,6 +135,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Player
       objectReference: {fileID: 0}
+    - target: {fileID: 4411930095043759998, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
+      propertyPath: _abilities.Array.data[0].Ability
+      value: 
+      objectReference: {fileID: 11400000, guid: 463a7fcd1a9d0f9409ff98607f284376, type: 2}
     - target: {fileID: 6949076173635677489, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0

--- a/Assets/ScriptableObject.meta
+++ b/Assets/ScriptableObject.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 71c552c151634ce40b9d4d3cc3dae9cd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObject/AbilitySO.meta
+++ b/Assets/ScriptableObject/AbilitySO.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e9685b8d1364e4d4581647ec07eb43c7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObject/AbilitySO/PlayerAttack.asset
+++ b/Assets/ScriptableObject/AbilitySO/PlayerAttack.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5da8bad903732fa459baf2c35624ff4e, type: 3}
+  m_Name: PlayerAttack
+  m_EditorClassIdentifier: 
+  BlockTimer: 1.5

--- a/Assets/ScriptableObject/AbilitySO/PlayerAttack.asset.meta
+++ b/Assets/ScriptableObject/AbilitySO/PlayerAttack.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 463a7fcd1a9d0f9409ff98607f284376
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/AbilitySystem/Abilities/BlockAbility.cs
+++ b/Assets/Scripts/AbilitySystem/Abilities/BlockAbility.cs
@@ -18,13 +18,13 @@ public class BlockAbility : GameplayAbility
     /// ⚠️반드시 부모(해당 클래스)의 Activate를 먼저 호출할 것<br/>
     /// 그래야만 다른 스킬들이 블락됨
     /// </summary>
-    protected override void Activate()
+    public override void Activate(GameplayAbilitySpec spec)
     {
-        ASC.TagContainer.AddWithDuration(GameplayTags.BlockRunningAbility, BlockTimer).Forget();
+        spec.Asc.TagContainer.AddWithDuration(GameplayTags.BlockRunningAbility, BlockTimer).Forget();
     }
 
-    protected override bool CanActivate()
+    public override bool CanActivate(GameplayAbilitySpec spec)
     {
-        return !ASC.TagContainer.Has(GameplayTags.BlockRunningAbility);
+        return !spec.Asc.TagContainer.Has(GameplayTags.BlockRunningAbility);
     }
 }

--- a/Assets/Scripts/AbilitySystem/Abilities/PlayerAttack.cs
+++ b/Assets/Scripts/AbilitySystem/Abilities/PlayerAttack.cs
@@ -5,13 +5,15 @@ using AbilitySystem.Base;
 using Unity.VisualScripting;
 
 
-public class PlayerAttack : GameplayAbility
+[CreateAssetMenu(menuName = "Ability/PlayerAttack")]
+public class PlayerAttack : BlockAbility
 {
     /// <summary>
     /// 실제 Ability 실행부
     /// </summary>
-    protected override void Activate() 
+    public override void Activate(GameplayAbilitySpec spec) 
     {
+        base.Activate(spec);
         Debug.Log("어빌리티 실행");
     }
     

--- a/Assets/Scripts/AbilitySystem/Base/AbilitySystem.cs
+++ b/Assets/Scripts/AbilitySystem/Base/AbilitySystem.cs
@@ -19,7 +19,7 @@ namespace AbilitySystem.Base
         [SerializeField]
         private List<AbilityComponent> _abilities = new();
 
-        private readonly Dictionary<string, GameplayAbility> _grantedAbilities = new();
+        private readonly Dictionary<string, GameplayAbilitySpec> _grantedAbilities = new();
         public readonly TagContainer TagContainer = new();
         public readonly GameplayAttribute Attribute = new();
         
@@ -31,8 +31,7 @@ namespace AbilitySystem.Base
         /// <param name="ability">Key에 바인딩 된 Ability</param>
         public bool GrantAbility(string key, GameplayAbility ability)
         {
-            ability.Init(this);
-            return _grantedAbilities.TryAdd(key, ability);
+            return _grantedAbilities.TryAdd(key, new GameplayAbilitySpec(this, ability));
         }
 
         /// <summary>
@@ -45,8 +44,7 @@ namespace AbilitySystem.Base
             {
                 if(ac.Ability != null)
                 {
-                    ac.Ability.Init(this);
-                    return _grantedAbilities.TryAdd(ac.Name, ac.Ability);
+                    return _grantedAbilities.TryAdd(ac.Name, new GameplayAbilitySpec(this, ac.Ability));
                 }
             }
             return false;
@@ -67,8 +65,7 @@ namespace AbilitySystem.Base
                 {
                     if (ac.UnlockFloor <= floor)
                     {
-                        ac.Ability.Init(this);
-                        return _grantedAbilities.TryAdd(ac.Name, ac.Ability);
+                        return _grantedAbilities.TryAdd(ac.Name, new GameplayAbilitySpec(this, ac.Ability));
                     }
                 }
             }

--- a/Assets/Scripts/AbilitySystem/Base/GameplayAbility.cs
+++ b/Assets/Scripts/AbilitySystem/Base/GameplayAbility.cs
@@ -2,35 +2,21 @@
 
 namespace AbilitySystem.Base
 {
-    public abstract class GameplayAbility : MonoBehaviour
+    /// <summary>
+    /// Ability의 실질적 데이터와 순수한 로직만을 저장
+    /// </summary>
+    public abstract class GameplayAbility : ScriptableObject
     {
-        protected AbilitySystem ASC;
-        public void Init(AbilitySystem asc)
-        {
-            ASC = asc;
-        }
-        
-        /// <summary>
-        /// Ability 실행 요청
-        /// </summary>
-        public void TryActivate()
-        {
-            if(CanActivate()) Activate();
-        }
-
         /// <summary>
         /// 실제 Ability 실행부
         /// </summary>
-        protected abstract void Activate();
+        public abstract void Activate(GameplayAbilitySpec spec);
 
         /// <summary>
         /// Ability를 실행할 수 있는지 여부 판단. <br/>
         /// 해당 함수를 override 해서 Ability 실행 여부를 결정할 수 있음.
         /// </summary>
         /// <returns>실행 가능 여부</returns>
-        protected virtual bool CanActivate()
-        {
-            return true;
-        }
+        public virtual bool CanActivate(GameplayAbilitySpec spec) => true;
     }
 }

--- a/Assets/Scripts/AbilitySystem/Base/GameplayAbilitySpec.cs
+++ b/Assets/Scripts/AbilitySystem/Base/GameplayAbilitySpec.cs
@@ -1,0 +1,26 @@
+﻿namespace AbilitySystem.Base
+{
+    /// <summary>
+    /// Ability의 상태 정보를 저장
+    /// </summary>
+    public class GameplayAbilitySpec
+    {
+        public AbilitySystem Asc;
+        private readonly GameplayAbility _ability;
+        
+        public GameplayAbilitySpec(AbilitySystem asc, GameplayAbility ability)
+        {
+            Asc = asc;
+            _ability = ability;
+        }
+        
+        /// <summary>
+        /// Ability 실행 요청
+        /// </summary>
+        public void TryActivate()
+        {
+            if(_ability.CanActivate(this)) 
+                _ability.Activate(this);
+        }
+    }
+}

--- a/Assets/Scripts/AbilitySystem/Base/GameplayAbilitySpec.cs.meta
+++ b/Assets/Scripts/AbilitySystem/Base/GameplayAbilitySpec.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 40eb4b15a5de4a0ca71c201416e6e14d
+timeCreated: 1751448806


### PR DESCRIPTION
## 사용방법

기본적으로 BlockAbility를 상속받아 구현(다른 스킬 사용 중에 사용 가능한 경우 그냥 GameplayAbility 상속)

### ⚠️[CreateAssetMenu(menuName = "Ability/스킬명")]을 클래스명 위에 붙여야 함
-> 그래야 기획자가 스킬 데이터를 ScriptableObject로 손쉽게 제작/수정할 수 있음!
```csharp
[CreateAssetMenu(menuName = "Ability/PlayerAttack")]
public class PlayerAttack : BlockAbility {}
```

* Ability 관련 ScriptableObject는 ScriptableObject  밑 AbilitySO 폴더에 저장
* 우클릭 -> 
<img width="462" alt="image" src="https://github.com/user-attachments/assets/b5968d57-9b8c-4b6b-b224-cd9c80bc725b" />

## 비고
* 데이터(float, 등... )/로직은 GameplayAbility
* 데이터를 제외한 상태는 GameplayAbilitySpec에서 관리