### PR TITLE
Fix: 몬스터 베이스 수정/리팩토링

### DIFF
--- a/Assets/Prefabs/Enemies/Monster1.prefab
+++ b/Assets/Prefabs/Enemies/Monster1.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 6341505062458276174}
   - component: {fileID: 4981719801117348745}
   - component: {fileID: 6332346728151343494}
-  - component: {fileID: 6534334383606119506}
+  - component: {fileID: 7104262623799682993}
   - component: {fileID: 4455798029593503710}
   - component: {fileID: 1637802669671784048}
   - component: {fileID: 5604168195167317945}
@@ -175,7 +175,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6e5927b46eaba8a449f61361d6ca3319, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &6534334383606119506
+--- !u!114 &7104262623799682993
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -184,11 +184,12 @@ MonoBehaviour:
   m_GameObject: {fileID: 7517215775904943170}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: af33d3b385b442e4daff2d4932ea3f4b, type: 3}
+  m_Script: {fileID: 11500000, guid: f210e56167f7ea746bd281bf660d3487, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   monsterData: {fileID: 11400000, guid: 487333a7b33cd654aaa8061057143775, type: 2}
   abilitySystemPath: Monster/Monster1
+  abilityKey: 6
 --- !u!114 &4455798029593503710
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -218,7 +219,6 @@ MonoBehaviour:
   platformLayer:
     serializedVersion: 2
     m_Bits: 8
-  player: {fileID: 6949076173635677489, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
 --- !u!114 &5604168195167317945
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -231,5 +231,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c6b4d6b24e35b0845b3a9ef4a97a0175, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  speed: 0.1
+  speed: 0.05
   gravity: 1

--- a/Assets/Resources/Monster/Monster1.asset
+++ b/Assets/Resources/Monster/Monster1.asset
@@ -17,4 +17,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 7f1e8d8ba753ac34984b22e39ced85e6, type: 2}
   - {fileID: 11400000, guid: 9c46fe18a6b53f841a852000208a1fd1, type: 2}
   AbilitySO:
-  - {fileID: 11400000, guid: 72bb72f23064453438529872c942449b, type: 2}
+  - {fileID: 11400000, guid: 0259533dbfae1674b96f8ce7f87bf429, type: 2}

--- a/Assets/Scenes/Test/TestMonster.unity
+++ b/Assets/Scenes/Test/TestMonster.unity
@@ -374,6 +374,63 @@ MonoBehaviour:
   pausePopup: {fileID: 8320787055283786393, guid: d477267dd7acb41828b3c1b972b6257c, type: 3}
   settingsPopup: {fileID: 3328791667321931522, guid: 54c15ebe0f8bd4d0d996885bff124dfa, type: 3}
   canvas: {fileID: 857090423}
+--- !u!1001 &229698007
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2384312483337340385, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
+      propertyPath: m_Name
+      value: Player (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6949076173635677489, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6949076173635677489, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6949076173635677489, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6949076173635677489, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6949076173635677489, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6949076173635677489, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6949076173635677489, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6949076173635677489, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6949076173635677489, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6949076173635677489, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
 --- !u!1 &342581574
 GameObject:
   m_ObjectHideFlags: 0
@@ -507,75 +564,11 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 342581574}
   m_CullTransparentMesh: 1
---- !u!1001 &462826032
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 1123411515258651070, guid: 68968d05dc65d194a9ddbeed392df257, type: 3}
-      propertyPath: m_DrawMode
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1637802669671784048, guid: 68968d05dc65d194a9ddbeed392df257, type: 3}
-      propertyPath: player
-      value: 
-      objectReference: {fileID: 1962800970}
-    - target: {fileID: 4303070911237890198, guid: 68968d05dc65d194a9ddbeed392df257, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 3.93
-      objectReference: {fileID: 0}
-    - target: {fileID: 4303070911237890198, guid: 68968d05dc65d194a9ddbeed392df257, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.53
-      objectReference: {fileID: 0}
-    - target: {fileID: 4303070911237890198, guid: 68968d05dc65d194a9ddbeed392df257, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4303070911237890198, guid: 68968d05dc65d194a9ddbeed392df257, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4303070911237890198, guid: 68968d05dc65d194a9ddbeed392df257, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4303070911237890198, guid: 68968d05dc65d194a9ddbeed392df257, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4303070911237890198, guid: 68968d05dc65d194a9ddbeed392df257, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4303070911237890198, guid: 68968d05dc65d194a9ddbeed392df257, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4303070911237890198, guid: 68968d05dc65d194a9ddbeed392df257, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4303070911237890198, guid: 68968d05dc65d194a9ddbeed392df257, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4455798029593503710, guid: 68968d05dc65d194a9ddbeed392df257, type: 3}
-      propertyPath: canvas
-      value: 
-      objectReference: {fileID: 1882700054}
-    - target: {fileID: 7517215775904943170, guid: 68968d05dc65d194a9ddbeed392df257, type: 3}
-      propertyPath: m_Name
-      value: Monster1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 68968d05dc65d194a9ddbeed392df257, type: 3}
+--- !u!1 &349186231 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 979007608525210321, guid: c53a21dfd0e09664ebcf1f84cda3fc6d, type: 3}
+  m_PrefabInstance: {fileID: 654465003}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &654465003
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1245,6 +1238,71 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 958440849}
   m_CullTransparentMesh: 1
+--- !u!1001 &1219548489
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4303070911237890198, guid: 68968d05dc65d194a9ddbeed392df257, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 14.13
+      objectReference: {fileID: 0}
+    - target: {fileID: 4303070911237890198, guid: 68968d05dc65d194a9ddbeed392df257, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.78
+      objectReference: {fileID: 0}
+    - target: {fileID: 4303070911237890198, guid: 68968d05dc65d194a9ddbeed392df257, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4303070911237890198, guid: 68968d05dc65d194a9ddbeed392df257, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4303070911237890198, guid: 68968d05dc65d194a9ddbeed392df257, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4303070911237890198, guid: 68968d05dc65d194a9ddbeed392df257, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4303070911237890198, guid: 68968d05dc65d194a9ddbeed392df257, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4303070911237890198, guid: 68968d05dc65d194a9ddbeed392df257, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4303070911237890198, guid: 68968d05dc65d194a9ddbeed392df257, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4303070911237890198, guid: 68968d05dc65d194a9ddbeed392df257, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4455798029593503710, guid: 68968d05dc65d194a9ddbeed392df257, type: 3}
+      propertyPath: canvas
+      value: 
+      objectReference: {fileID: 349186231}
+    - target: {fileID: 5604168195167317945, guid: 68968d05dc65d194a9ddbeed392df257, type: 3}
+      propertyPath: speed
+      value: 0.05
+      objectReference: {fileID: 0}
+    - target: {fileID: 7517215775904943170, guid: 68968d05dc65d194a9ddbeed392df257, type: 3}
+      propertyPath: m_Name
+      value: Monster1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 68968d05dc65d194a9ddbeed392df257, type: 3}
 --- !u!1 &1239255603
 GameObject:
   m_ObjectHideFlags: 0
@@ -1602,98 +1660,6 @@ RectTransform:
   m_AnchoredPosition: {x: -886.3671, y: 457.36414}
   m_SizeDelta: {x: 147.2657, y: 165.2718}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &1497216745
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1497216748}
-  - component: {fileID: 1497216747}
-  - component: {fileID: 1497216746}
-  m_Layer: 0
-  m_Name: Main Camera
-  m_TagString: MainCamera
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!81 &1497216746
-AudioListener:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1497216745}
-  m_Enabled: 0
---- !u!20 &1497216747
-Camera:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1497216745}
-  m_Enabled: 1
-  serializedVersion: 2
-  m_ClearFlags: 1
-  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
-  m_projectionMatrixMode: 1
-  m_GateFitMode: 2
-  m_FOVAxisMode: 0
-  m_Iso: 200
-  m_ShutterSpeed: 0.005
-  m_Aperture: 16
-  m_FocusDistance: 10
-  m_FocalLength: 50
-  m_BladeCount: 5
-  m_Curvature: {x: 2, y: 11}
-  m_BarrelClipping: 0.25
-  m_Anamorphism: 0
-  m_SensorSize: {x: 36, y: 24}
-  m_LensShift: {x: 0, y: 0}
-  m_NormalizedViewPortRect:
-    serializedVersion: 2
-    x: 0
-    y: 0
-    width: 1
-    height: 1
-  near clip plane: 0.3
-  far clip plane: 1000
-  field of view: 60
-  orthographic: 1
-  orthographic size: 5
-  m_Depth: -1
-  m_CullingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_RenderingPath: -1
-  m_TargetTexture: {fileID: 0}
-  m_TargetDisplay: 0
-  m_TargetEye: 3
-  m_HDR: 1
-  m_AllowMSAA: 1
-  m_AllowDynamicResolution: 0
-  m_ForceIntoRT: 0
-  m_OcclusionCulling: 1
-  m_StereoConvergence: 10
-  m_StereoSeparation: 0.022
---- !u!4 &1497216748
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1497216745}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -10}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1574713190
 GameObject:
   m_ObjectHideFlags: 0
@@ -2287,128 +2253,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bac45a520a88848dab3a228c724cc2cf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &1882700054 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 979007608525210321, guid: c53a21dfd0e09664ebcf1f84cda3fc6d, type: 3}
-  m_PrefabInstance: {fileID: 654465003}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1962800959
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 2384312483337340385, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
-      propertyPath: m_Name
-      value: Player
-      objectReference: {fileID: 0}
-    - target: {fileID: 2384312483337340385, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
-      propertyPath: m_TagString
-      value: Player
-      objectReference: {fileID: 0}
-    - target: {fileID: 4572241603367076480, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
-      propertyPath: m_ActionEvents.Array.size
-      value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 4572241603367076480, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
-      propertyPath: m_ActionEvents.Array.data[7].m_ActionId
-      value: 51420271-4908-481b-b51d-ee0c34139011
-      objectReference: {fileID: 0}
-    - target: {fileID: 4572241603367076480, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
-      propertyPath: m_ActionEvents.Array.data[7].m_ActionName
-      value: PlayerActions/LanternInteraction[/Keyboard/e]
-      objectReference: {fileID: 0}
-    - target: {fileID: 4572241603367076480, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
-      propertyPath: m_ActionEvents.Array.data[7].m_PersistentCalls.m_Calls.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4572241603367076480, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
-      propertyPath: m_ActionEvents.Array.data[7].m_PersistentCalls.m_Calls.Array.data[0].m_Mode
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4572241603367076480, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
-      propertyPath: m_ActionEvents.Array.data[7].m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 1962800960}
-    - target: {fileID: 4572241603367076480, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
-      propertyPath: m_ActionEvents.Array.data[7].m_PersistentCalls.m_Calls.Array.data[0].m_CallState
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 4572241603367076480, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
-      propertyPath: m_ActionEvents.Array.data[7].m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: OnLanternInteraction
-      objectReference: {fileID: 0}
-    - target: {fileID: 4572241603367076480, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
-      propertyPath: m_ActionEvents.Array.data[7].m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
-      value: PlayerController, Assembly-CSharp
-      objectReference: {fileID: 0}
-    - target: {fileID: 4572241603367076480, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
-      propertyPath: m_ActionEvents.Array.data[7].m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.Object, UnityEngine
-      objectReference: {fileID: 0}
-    - target: {fileID: 6949076173635677489, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -4.4799805
-      objectReference: {fileID: 0}
-    - target: {fileID: 6949076173635677489, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -1.0599976
-      objectReference: {fileID: 0}
-    - target: {fileID: 6949076173635677489, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6949076173635677489, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6949076173635677489, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6949076173635677489, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6949076173635677489, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6949076173635677489, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6949076173635677489, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6949076173635677489, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
---- !u!114 &1962800960 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2677374988490091879, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
-  m_PrefabInstance: {fileID: 1962800959}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9430db4e1184cc548b7548daa9c083a7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!4 &1962800970 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 6949076173635677489, guid: a26cacc722720824abf1e6b05e88716d, type: 3}
-  m_PrefabInstance: {fileID: 1962800959}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &2063259421 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 821780820791739754, guid: 90334fdf476fa4f55ad0197e0c3ed0cb, type: 3}
@@ -2629,9 +2473,8 @@ PrefabInstance:
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
-  - {fileID: 1497216748}
   - {fileID: 654465003}
   - {fileID: 907291004}
-  - {fileID: 1962800959}
   - {fileID: 864239127}
-  - {fileID: 462826032}
+  - {fileID: 1219548489}
+  - {fileID: 229698007}

--- a/Assets/ScriptableObject/AbilitySO/Monster1Attack.asset
+++ b/Assets/ScriptableObject/AbilitySO/Monster1Attack.asset
@@ -9,10 +9,15 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bbb0084e2d584494bcbddb36a193020a, type: 3}
-  m_Name: MonsterAttack
+  m_Script: {fileID: 11500000, guid: ea0c827ce48ab934dac2347f4033c387, type: 3}
+  m_Name: Monster1Attack
   m_EditorClassIdentifier: 
   skillKey: 6
   skillName: 6
-  skillIcon: {fileID: 21300000, guid: 32e827b1a07fb478eb79678e868bba36, type: 3}
-  description: Monster "itai"
+  skillIcon: {fileID: 0}
+  description: 
+  BlockTimer: 1
+  AttackRangeX: 2
+  AttackRangeY: 2
+  AttackDir: 1
+  AttackHitboxPrefab: {fileID: 5257110030182595671, guid: e62b36397708f764e9785b839fae8a26, type: 3}

--- a/Assets/ScriptableObject/AbilitySO/Monster1Attack.asset.meta
+++ b/Assets/ScriptableObject/AbilitySO/Monster1Attack.asset.meta
@@ -1,8 +1,8 @@
 fileFormatVersion: 2
-guid: 2fdc56d0d44f63f439824d5c7f5406e6
-folderAsset: yes
-DefaultImporter:
+guid: 0259533dbfae1674b96f8ce7f87bf429
+NativeFormatImporter:
   externalObjects: {}
+  mainObjectFileID: 11400000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/ScriptableObject/MonsterSO/Monster1SO.asset
+++ b/Assets/ScriptableObject/MonsterSO/Monster1SO.asset
@@ -14,13 +14,12 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   monsterName: Monster1
   isParrying: 1
-  viewSight: 90
+  viewStartAngle: -22.5
+  viewSight: 45
   aggroRange: 8
   aggroReleaseRange: 14
   isFlying: 0
   pausedTime: 3
-  attackRangeX: 2
-  attackRangeY: 2
-  attackDir: 1
-  attackHitboxPrefab: {fileID: 5257110030182595671, guid: e62b36397708f764e9785b839fae8a26, type: 3}
   patrolRange: 6
+  detectRangeX: 1.5
+  detectRangeY: 1.5

--- a/Assets/Scripts/Monster/Monster.cs
+++ b/Assets/Scripts/Monster/Monster.cs
@@ -1,20 +1,22 @@
-﻿// Monster.cs
-using UnityEngine;
+﻿using UnityEngine;
 using GameAbilitySystem;
 
-public class Monster : MonoBehaviour
+public abstract class Monster : MonoBehaviour
 {
-    
     public AbilitySystem asc { get; private set; }
-    
+
     [SerializeField] private MonsterSO monsterData;
     public MonsterSO Data => monsterData;
-    
+
     [SerializeField] private string abilitySystemPath = "";
     private SpriteRenderer spriteRenderer;
     private float prevHp;
-    public bool isAggro { get; private set; }  = false;
-    
+    public bool isAggro { get; private set; } = false; //hp바 띄우는 것 때문에 넣어둠
+
+    private MonsterMovement _movement;
+    private Transform player;
+    public Transform Player => player;
+
     private void Awake()
     {
         // ASC 초기화
@@ -22,25 +24,120 @@ public class Monster : MonoBehaviour
         asc.SetSceneState(this.gameObject);
         asc.Init(abilitySystemPath);
         asc.GrantAllAbilities();
+
         prevHp = asc.Attribute.Attributes["HP"].CurrentValue.Value;
         spriteRenderer = GetComponent<SpriteRenderer>();
+        _movement = GetComponent<MonsterMovement>();
+        player = GameObject.FindWithTag("Player")?.transform;
     }
 
     private void Update()
     {
         float currHp = asc.Attribute.Attributes["HP"].CurrentValue.Value;
         if (currHp < prevHp)
-            StartCoroutine(Flash());
+            StartCoroutine(Flash()); //공격받았을 때 반짝 이펙트
         prevHp = currHp;
-        
+
         // 사망 처리
-        if (currHp <= 0f){
-            Debug.Log($"[Monster] 처치");
+        if (currHp <= 0f)
+        {
+            Debug.Log("[Monster] 처치");
             Destroy(this.gameObject);
         }
-            
+
+        if (player == null) return;
+
+        float dist = Vector2.Distance(transform.position, player.position);
+        bool inSight = IsPlayerInSight();
+        //플레이어가 시야에 들어오면 어그로 처리
+        if (dist <= Data.AggroRange && inSight)
+        {
+            isAggro = true;
+        }
+        else if (isAggro && dist >= Data.AggroReleaseRange)
+        {
+            isAggro = false;
+        }
+
+        //어그로 걸려 있고, 공격범위 안에 들어오면 Ability 실행
+        if (isAggro && IsPlayerInAttackRange())
+        {
+            EnterAttackRange();
+        }
     }
 
+    protected abstract void EnterAttackRange();
+
+    //플레이어가 시야 안에 들어오는지 체크 (부채꼴 범위)
+    //---------------------------------------------------
+    public bool IsPlayerInSight()
+    {
+        if (player == null) return false;
+
+        Vector2 toPlayer = (player.position - transform.position).normalized;
+        float angleToPlayer = Mathf.Atan2(toPlayer.y, toPlayer.x) * Mathf.Rad2Deg;
+        angleToPlayer = NormalizeAngle(angleToPlayer);
+
+        float startAngle = Data.ViewStartAngle;
+        float viewAngle = Data.ViewSight;
+
+        int dir = _movement != null ? _movement.GetDirection() : 1;
+
+        if (dir == -1)
+        {
+            startAngle = 180f - (startAngle + viewAngle);
+        }
+
+        startAngle = NormalizeAngle(startAngle);
+        float endAngle = NormalizeAngle(startAngle + viewAngle);
+
+        return IsAngleInRange(angleToPlayer, startAngle, endAngle);
+    }
+
+    private float NormalizeAngle(float angle)
+    {
+        angle %= 360f;
+        if (angle < 0f) angle += 360f;
+        return angle;
+    }
+
+    private bool IsAngleInRange(float angle, float start, float end)
+    {
+        if (start < end)
+            return angle >= start && angle <= end;
+        else
+            return angle >= start || angle <= end;
+    }
+    //---------------------------------------------------
+
+    
+    
+    //플레이어가 공격 범위 안에 들어오는지 체크 (사각 범위)
+    //---------------------------------------------------
+    private bool IsPlayerInAttackRange()
+    {
+        if (player == null) return false;
+
+        float detectX = Data.DetectRangeX;
+        float detectY = Data.DetectRangeY;
+        int facingDir = _movement != null ? _movement.GetDirection() : 1;
+
+        Vector2 offset = new Vector2(facingDir * (detectX / 2f + 0.2f), 0f);
+        Vector2 origin = (Vector2)transform.position + offset;
+        Collider2D[] hits = Physics2D.OverlapBoxAll(origin, new Vector2(detectX, detectY), 0f);
+
+        foreach (var hit in hits)
+        {
+            if (hit.CompareTag("Player"))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+    //---------------------------------------------------
+
+    //피격 시 반짝
     private System.Collections.IEnumerator Flash()
     {
         var prev = spriteRenderer.color;
@@ -48,9 +145,33 @@ public class Monster : MonoBehaviour
         yield return new WaitForSeconds(0.1f);
         spriteRenderer.color = prev;
     }
-
-    public void SetAggroState(bool state)
+    
+    //디버깅용 기즈모
+    #if UNITY_EDITOR
+    private void OnDrawGizmosSelected()
     {
-        isAggro = state;
+        if (monsterData == null) return;
+
+        //공격 시작 범위
+        int facingDir = Application.isPlaying && _movement != null ? _movement.GetDirection() : 1;
+        float detectX = monsterData.DetectRangeX;
+        float detectY = monsterData.DetectRangeY;
+        Vector2 offset = new Vector2(facingDir * (detectX / 2f + 0.2f), 0f);
+        Vector2 origin = (Vector2)transform.position + offset;
+        Gizmos.color = new Color(1f, 0.3f, 0.2f, 0.4f);
+        Gizmos.DrawCube(origin, new Vector3(detectX, detectY, 0.1f));
+        
+        //몬스터 시야 범위
+        float startAngle = monsterData.ViewStartAngle;
+        float viewAngle = monsterData.ViewSight;
+
+        if (facingDir == -1)
+        {
+            startAngle = 180f - (startAngle + viewAngle);
+        }
+        startAngle %= 360f;
+        UnityEditor.Handles.color = new Color(1f, 1f, 0f, 0.25f);
+        UnityEditor.Handles.DrawSolidArc(transform.position, Vector3.forward, Quaternion.Euler(0, 0, startAngle) * Vector3.right, viewAngle, monsterData.AggroRange);
     }
+    #endif
 }

--- a/Assets/Scripts/Monster/Monster1.cs
+++ b/Assets/Scripts/Monster/Monster1.cs
@@ -1,0 +1,12 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Monster1 : Monster
+{
+    public AbilityKey abilityKey;
+    
+    protected override void EnterAttackRange(){
+        asc.TryActivateAbility(abilityKey);
+    }
+}

--- a/Assets/Scripts/Monster/Monster1.cs.meta
+++ b/Assets/Scripts/Monster/Monster1.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f210e56167f7ea746bd281bf660d3487
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Monster/MonsterMovement.cs
+++ b/Assets/Scripts/Monster/MonsterMovement.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections;
-using UnityEngine;
+﻿using UnityEngine;
 
 public enum MovePattern
 {
@@ -21,10 +20,9 @@ public class MonsterMovement : MonoBehaviour
 
     private bool isPaused = false;
     private float pauseTimer = 0;
-    private bool isAttacking = false;
-    
+    private Transform player;
+
     [SerializeField] private LayerMask platformLayer;
-    [SerializeField] private Transform player;
 
     private void Start()
     {
@@ -35,8 +33,11 @@ public class MonsterMovement : MonoBehaviour
         spawnPos = transform.position;
         patrolPos = spawnPos + new Vector2(-monster.Data.PatrolRange / 2f, 0);
 
+        player = monster.Player;
+
         if (player == null)
             player = GameObject.FindWithTag("Player")?.transform;
+
     }
 
     private void Update()
@@ -45,20 +46,13 @@ public class MonsterMovement : MonoBehaviour
 
         float dist = Vector2.Distance(transform.position, player.position);
 
-        // 시야각 계산
-        Vector2 toPlayer = (player.position - transform.position).normalized;
-        Vector2 forward = Vector2.right * dir;
-        float angle = Vector2.Angle(forward, toPlayer);
-
-        if (dist <= monster.Data.AggroRange && angle <= monster.Data.ViewSight / 2f)
+        if (monster.isAggro)
         {
             moveState = MovePattern.Aggro;
-            monster.SetAggroState(true);
         }
         else if (moveState == MovePattern.Aggro && dist >= monster.Data.AggroReleaseRange)
         {
             moveState = MovePattern.Return;
-            monster.SetAggroState(false);
         }
 
         switch (moveState)
@@ -77,8 +71,14 @@ public class MonsterMovement : MonoBehaviour
                     dir = 1;
                     patrolPos = spawnPos + new Vector2(-monster.Data.PatrolRange / 2f, 0);
                 }
+
                 break;
         }
+    }
+
+    public void ChangeMovePattern(MovePattern pattern)
+    {
+        moveState = pattern;
     }
 
     private void PatrolMove()
@@ -93,6 +93,7 @@ public class MonsterMovement : MonoBehaviour
                 dir *= -1;
                 patrolPos = transform.position;
             }
+
             cm.Move(Vector2.zero);
             return;
         }
@@ -123,28 +124,11 @@ public class MonsterMovement : MonoBehaviour
             cm.Move(Vector2.zero);
             return;
         }
-
-        if (IsPlayerTouched())
-        {
-            cm.Move(Vector2.zero);
-        }
+        
         else
         {
             cm.Move(Vector2.right * dir);
         }
-
-        monster.asc.TryActivateAbility(AbilityKey.MonsterAttack);
-    }
-
-
-    private bool IsPlayerTouched()
-    {
-        if (player == null || monsterCollider == null) return false;
-
-        Collider2D playerCollider = player.GetComponent<Collider2D>();
-        if (playerCollider == null) return false;
-
-        return monsterCollider.IsTouching(playerCollider);
     }
 
 
@@ -175,61 +159,4 @@ public class MonsterMovement : MonoBehaviour
     }
 
     public int GetDirection() => dir;
-
-    
-    //어그로 범위, 공격 범위 시각화
-    private void OnDrawGizmosSelected()
-    {
-    #if UNITY_EDITOR
-        if (monster == null) monster = GetComponent<Monster>();
-        if (monster == null || monster.Data == null) return;
-
-        Vector3 origin = transform.position;
-        Vector2 forward = Vector2.right * dir;
-
-        // 1. 시야각 + 어그로 범위
-        float viewSight = monster.Data.ViewSight;
-        float aggroRange = monster.Data.AggroRange;
-        float releaseRange = monster.Data.AggroReleaseRange;
-
-        float halfAngle = viewSight / 2f;
-
-        Gizmos.color = new Color(1f, 1f, 0f, 0.3f);
-        Vector3 left = Quaternion.Euler(0, 0, -halfAngle) * forward;
-        Vector3 right = Quaternion.Euler(0, 0, halfAngle) * forward;
-        Gizmos.DrawRay(origin, left * aggroRange);
-        Gizmos.DrawRay(origin, right * aggroRange);
-
-        Gizmos.color = new Color(0f, 1f, 0f, 0.2f);
-        Gizmos.DrawWireSphere(origin, aggroRange);
-
-        Gizmos.color = new Color(1f, 0f, 0f, 0.2f);
-        Gizmos.DrawWireSphere(origin, releaseRange);
-
-        // 2. 공격 범위 표시
-        float rangeX = monster.Data.AttackRangeX;
-        float rangeY = monster.Data.AttackRangeY;
-        int dirCode = monster.Data.AttackDir;
-
-        float angleDeg = 0f;
-        switch (dirCode)
-        {
-            case 1: angleDeg = 0f; break;
-            case 2: angleDeg = 270f; break;
-        }
-
-        if ((dirCode == 1 || dirCode == 4) && dir == -1)
-        {
-            angleDeg = 180f - angleDeg;
-        }
-
-        float angleRad = angleDeg * Mathf.Deg2Rad;
-        Vector2 attackDir = new Vector2(Mathf.Cos(angleRad), Mathf.Sin(angleRad)).normalized;
-        Vector2 offset = attackDir * new Vector2(rangeX / 2f, rangeY / 2f);
-        Vector2 attackOrigin = (Vector2)transform.position + offset;
-
-        Gizmos.color = Color.red;
-        Gizmos.DrawWireCube(attackOrigin, new Vector2(rangeX, rangeY));
-#endif
-    }
 }

--- a/Assets/Scripts/Monster/UI_MonsterHpBar.cs
+++ b/Assets/Scripts/Monster/UI_MonsterHpBar.cs
@@ -6,7 +6,7 @@ using System.Collections;
 public class UI_MonsterHpBar : MonoBehaviour
 {
     public GameObject prfHpBar;
-    public GameObject canvas;
+    private GameObject canvas;
 
     private RectTransform hpBar;
     private Image hpImage;
@@ -20,10 +20,15 @@ public class UI_MonsterHpBar : MonoBehaviour
     private IEnumerator Start()
     {
         monster = GetComponent<Monster>();
+        if (canvas == null)
+        {
+            GameObject found = GameObject.Find("BaseCanvas");
+            if (found != null)
+                canvas = found;
+        }
 
         while (!monster.asc.Attribute.Attributes.ContainsKey("HP"))
             yield return null;
-
         hp = monster.asc.Attribute.Attributes["HP"];
 
         hpBar = Instantiate(prfHpBar, canvas.transform).GetComponent<RectTransform>();
@@ -44,7 +49,7 @@ public class UI_MonsterHpBar : MonoBehaviour
         if (TryGetComponent<Collider2D>(out var col))
             offsetY = col.bounds.size.y + 0.3f;
 
-        Vector3 worldPos = transform.position + new Vector3(0, offsetY - 0.5f, 0);
+        Vector3 worldPos = transform.position + new Vector3(0, offsetY - 0.3f, 0);
         Vector2 screenPos = Camera.main.WorldToScreenPoint(worldPos);
         screenPos.y -= 20f;
         hpBar.position = screenPos;

--- a/Assets/Scripts/SO/AbilitySO/MonsterAttackSO.cs
+++ b/Assets/Scripts/SO/AbilitySO/MonsterAttackSO.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+using GameAbilitySystem;
+
+public enum AttackDirection
+{
+    Front = 1,
+    Up = 2,
+    Down = 3
+}
+[CreateAssetMenu(menuName = "Ability/MonsterAttackSO")]
+
+public class MonsterAttackSO : BlockAbilitySO
+{
+    [Header("공격 관련")]
+    public float AttackRangeX = 2f;
+    public float AttackRangeY = 2f;
+    public AttackDirection AttackDir = AttackDirection.Front;
+    public GameObject AttackHitboxPrefab;
+    
+}

--- a/Assets/Scripts/SO/AbilitySO/MonsterAttackSO.cs.meta
+++ b/Assets/Scripts/SO/AbilitySO/MonsterAttackSO.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ea0c827ce48ab934dac2347f4033c387
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/SO/MonsterSO.cs
+++ b/Assets/Scripts/SO/MonsterSO.cs
@@ -5,38 +5,33 @@ public class MonsterSO : ScriptableObject
 {
     [Header("기본 정보")]
     [SerializeField] private string monsterName = "";
-    [SerializeField] private bool isParrying = true;
-    
-
+    [SerializeField] private bool isFlying = false;               // 공중 몬스터 여부
     public string MonsterName => monsterName;
-    public bool IsParrying => isParrying;
+    public bool IsFlying => isFlying;
 
-    [Header("AI 시야 / 이동")]
+    [Header("시야각")]
+    [SerializeField] private float viewStartAngle = -45f; // 시작 각도 (왼쪽부터)
     [SerializeField] private float viewSight = 90f;               // 시야각 부채꼴 각도
+    
+    [Header("어그로 / 해제 거리")]
     [SerializeField] private float aggroRange = 8f;               // 부채꼴 반지름 (어그로 끌리는 거리)
     [SerializeField] private float aggroReleaseRange = 14f;       // 어그로 해제 거리
-    [SerializeField] private bool isFlying = false;               // 공중 몬스터 여부
-    [SerializeField] private float pausedTime = 3f;             
+    
+    private float pausedTime = 3f;             
+    private float patrolRange = 6f; //어그로 안끌렸을때 이동 반경
 
+    public float ViewStartAngle => viewStartAngle;
     public float ViewSight => viewSight;
     public float AggroRange => aggroRange;
     public float AggroReleaseRange => aggroReleaseRange;
-    public bool IsFlying => isFlying;
     public float PausedTime => pausedTime;
-
-    [Header("공격 관련")]
-    [SerializeField] private float attackRangeX = 2f; // 공격 가로 범위
-    [SerializeField] private float attackRangeY = 2f; // 공격 세로 범위
-    [SerializeField] private int attackDir = 1; // 몹 중앙 기준 공격 방향 (1=전방, 2=하단)
-    [SerializeField] private GameObject attackHitboxPrefab;
-    public GameObject AttackHitboxPrefab => attackHitboxPrefab;
-
-    public float AttackRangeX => attackRangeX;
-    public float AttackRangeY => attackRangeY;
-    public int AttackDir => attackDir;
-
-    [Header("이동 설정")]
-    [SerializeField] private float patrolRange = 6f; //어그로 안끌렸을때 이동 반경
-
     public float PatrolRange => patrolRange;
+
+    
+    [Header("공격 시작 인식 범위")]
+    [SerializeField] private float detectRangeX = 1.5f;
+    [SerializeField] private float detectRangeY = 1.5f;
+    public float DetectRangeX => detectRangeX;
+    public float DetectRangeY => detectRangeY;
+    
 }


### PR DESCRIPTION
몬제가에 업데이트 예정

(1) MonsterMovement 일부를 Monster로 옮김, MonsterMovement에서는 이동 처리만 (몬스터 시야, 공격 시작 범위 체크를 Monster.cs로 옮김)
-> 시야 부채꼴의 경우 시작지점 지정하여 시야 범위를 유동적으로 설정할 수 있게 바꿨음

(2) MonsterAttackSO 만들어서 공격 관련 정보는 해당 SO에 담기도록 분리 

(3) BlockAbility 상속받아 쿨타임 구현

(4) 플레이어 자동으로 찾도록 변경 

(5) 공격 방향 (AttackDir) enum으로 바꿔서 조금 더 직관적이게 변경... (더나은방법은없을까) 