### PR TITLE
Feat: Attribute에 Max값을 Attribute로 제한할 수 있는 기능 추가

### DIFF
--- a/Assets/Resources/Domain/Player.asset
+++ b/Assets/Resources/Domain/Player.asset
@@ -17,6 +17,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 25198eb9af2572b4c954ce5c81d9c2db, type: 2}
   - {fileID: 11400000, guid: 1181ea6d331a7104496d652e92eb019e, type: 2}
   - {fileID: 11400000, guid: fa6b8cbe1df927a4facb2abfb35b81b6, type: 2}
+  - {fileID: 11400000, guid: 574aa22de096387498112ada6bc2a024, type: 2}
   AbilitySO:
   - {fileID: 11400000, guid: 62031bc535894774eabc9f7b7b01b696, type: 2}
   - {fileID: 11400000, guid: 25fba1fe77f2e3a46be11598a35c3f82, type: 2}

--- a/Assets/ScriptableObject/AttributeSO/MaxHP.asset
+++ b/Assets/ScriptableObject/AttributeSO/MaxHP.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7755f0eb93a0da648bfa6f2271526407, type: 3}
+  m_Name: MaxHP
+  m_EditorClassIdentifier: 
+  AttributeName: MaxHP
+  BaseValue: 5
+  MaxValue: 6

--- a/Assets/ScriptableObject/AttributeSO/MaxHP.asset.meta
+++ b/Assets/ScriptableObject/AttributeSO/MaxHP.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 574aa22de096387498112ada6bc2a024
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/AbilitySystem/Base/GameplayAttribute.cs
+++ b/Assets/Scripts/AbilitySystem/Base/GameplayAttribute.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using JetBrains.Annotations;
 using Newtonsoft.Json;
 using R3;
 using UnityEngine;
@@ -19,7 +20,8 @@ namespace GameAbilitySystem
         private AttributeSO _attributeSo;
         public float BaseValue => _attributeSo.BaseValue;
         public ReactiveProperty<float> CurrentValue { get; private set; }
-        public float MaxValue => _attributeSo.MaxValue;
+        public float MaxValue => _maxValue is null ? _attributeSo.MaxValue : _maxValue.CurrentValue.Value;
+        [CanBeNull] public Attribute _maxValue { private get; set; }
         
         //public event Action<float>? OnValueChanged;
 
@@ -83,6 +85,10 @@ namespace GameAbilitySystem
             foreach (var att in dict)
             {
                 Attributes[att.Key].SetCurrentValue(att.Value);
+                if(Attributes.TryGetValue($"Max{att.Key}", out var maxAtt))
+                {
+                    Attributes[att.Key]._maxValue = maxAtt;
+                }
             }
         }
 


### PR DESCRIPTION
## 구현 내용

AttributeName을 다른 Attribute의 Max로 지으면(Ex. HP면 MaxHP) 해당 Attribute가 자동으로 Max 제한값이 됨(최대 체력을 늘리고 싶다면 해당 Attribute를 조정하면 됨